### PR TITLE
[+] added prometheus-counters

### DIFF
--- a/10-lesson/gosearch/cmd/gosearch/go.mod
+++ b/10-lesson/gosearch/cmd/gosearch/go.mod
@@ -16,6 +16,7 @@ replace (
 
 require (
 	github.com/gorilla/mux v1.8.0
+	github.com/prometheus/client_golang v1.8.0
 	google.golang.org/protobuf v1.25.0 // indirect
 	gosearch/pkg/api v0.0.0-00010101000000-000000000000
 	gosearch/pkg/crawler v0.0.0-00010101000000-000000000000

--- a/10-lesson/gosearch/cmd/gosearch/main.go
+++ b/10-lesson/gosearch/cmd/gosearch/main.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"gosearch/pkg/api"
 	"gosearch/pkg/crawler"
 	"gosearch/pkg/crawler/spider"
@@ -32,6 +35,13 @@ type gosearch struct {
 	depth int
 	addr  string
 }
+
+// Счетчик prometheus
+// Значение за все время: gs_documents_total
+var documentsTotal = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "gs_documents_total",
+	Help: "Количество документов в БД.",
+})
 
 func main() {
 	server := new()
@@ -76,6 +86,8 @@ func (gs *gosearch) init() {
 			log.Println("ошибка при добавлении сохранении документов в БД:", err)
 			continue
 		}
+		// Добавляем кол-во новых документов в prometheus-счетчик
+		documentsTotal.Add(len(data))
 	}
 }
 

--- a/10-lesson/gosearch/pkg/index/hash/go.mod
+++ b/10-lesson/gosearch/pkg/index/hash/go.mod
@@ -4,4 +4,7 @@ go 1.15
 
 replace gosearch/pkg/crawler => ../../crawler
 
-require gosearch/pkg/crawler v0.0.0-00010101000000-000000000000
+require (
+	github.com/prometheus/client_golang v1.8.0
+	gosearch/pkg/crawler v0.0.0-00010101000000-000000000000
+)

--- a/10-lesson/gosearch/pkg/index/hash/hash.go
+++ b/10-lesson/gosearch/pkg/index/hash/hash.go
@@ -3,6 +3,9 @@ package hash
 import (
 	"gosearch/pkg/crawler"
 	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 // Index - индекс на основе хэш-таблицы.
@@ -17,6 +20,13 @@ func New() *Index {
 	return &ind
 }
 
+// счетчик prometheus
+// Значение за все время: gs_index_length
+var indexLength = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "gs_index_length",
+	Help: "Длина индекса.",
+})
+
 // Add добавляет данные из переданных документов в индекс.
 //
 // Сначала происходит выделение лексем как ключей словаря из данных документа.
@@ -27,6 +37,8 @@ func (index *Index) Add(docs []crawler.Document) {
 		for _, token := range tokens(doc.Title) {
 			if !exists(index.data[token], doc.ID) {
 				index.data[token] = append(index.data[token], doc.ID)
+				// Увеличиваем prometheus-счетчик длины индекса
+				indexLength.Inc()
 			}
 		}
 	}


### PR DESCRIPTION
Здесь представлен diff к оригинальному коду gosearch из учебного репозитория.
Добавлена гистограмма searchRequestSize в api.go для длины поисковой фразы.
Добавлен счетчик кол-ва документов в main.go и счетчик кол-ва записей в индексе в пакет index/hash/hash.go
Заметил такую странность: счетчики кол-ва документов и длины индекса сбрасываются в приложение prometheus только после старта вебсервера в api.go и сразу в готовом виде, т.е. не удается получить по ним график увеличения. Не понял как побороть это, не запускать же сервер раньше, чем построится индекс...